### PR TITLE
Updated the version to be in line with latest release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jwmodel
 Title: Toolset For Suggesting And Analysing Judicial Workforce Hiring Profiles
-Version: 0.0.0.9012
+Version: 0.0.3
 Authors@R: 
     person(given = "Tom",
            family = "Dewar",


### PR DESCRIPTION
Just prepare for app-migration. 

Since the repo has been made public,  installation of this R package in https://github.com/moj-analytical-services/judicial-wm2 can be through `renv::install("moj-analytical-services/jwmodel")`  , then it will be part of renv.lock file (renv::snapshot()). it will be easier, 

I tried the above approach, found out the version in DESCRIPTION does't match the release version,  this PR is to correct it